### PR TITLE
Improve A* neighbour cost update

### DIFF
--- a/js/logic.js
+++ b/js/logic.js
@@ -100,18 +100,17 @@ function aStarAlgorithm(grid) {
                 return;
             }
 
-            if(!openList.find(node => node == neighbour)) {
+            const moveCost = currentNode.gCost + ((currentNode.x === neighbour.x || currentNode.y === neighbour.y) ? 10 : 14);
+            let isNodeInOpen = openList.find(node => (node.x == neighbour.x) && (node.y == neighbour.y)) ? true : false;
+
+            if(moveCost < neighbour.gCost || !isNodeInOpen) {
+                neighbour.gCost = moveCost;
+                neighbour.fCost = neighbour.gCost + neighbour.hCost;
                 neighbour.setParent(currentNode);
-                neighbour.calcFCost();
-                
-                let isNodeInOpen = openList.find(node => (node.x == neighbour.x) && (node.y == neighbour.y)) ? true : false;
+
                 if (!isNodeInOpen) {
                     openList.push(neighbour);
                 }
-                /*
-                Note: If we calculate gCost each time that we access a new node,
-                we won't need to go to the starting node
-                */
             }
         });
     }
@@ -296,4 +295,8 @@ function loadAlgorithm(algorithmNumber, grid) {
         default:
             break;
     }
+}
+
+if (typeof module !== 'undefined') {
+    module.exports = { Node, WallNode, aStarAlgorithm, initGrid, loadAlgorithm };
 }

--- a/tests/improvement.js
+++ b/tests/improvement.js
@@ -1,0 +1,21 @@
+const { loadAlgorithm } = require('../js/logic.js');
+
+const blocked = [
+  [0,0,1,0,3],
+  [0,0,1,0,0],
+  [2,0,1,0,0],
+  [0,0,1,0,0],
+  [0,0,0,0,0]
+];
+
+const shortcut = [
+  [0,0,1,0,3],
+  [0,0,1,0,0],
+  [2,0,0,0,0],
+  [0,0,1,0,0],
+  [0,0,0,0,0]
+];
+
+console.log('Blocked path length:', loadAlgorithm(0, blocked).length);
+console.log('Shortcut path length:', loadAlgorithm(0, shortcut).length);
+


### PR DESCRIPTION
## Summary
- update neighbour iteration so gCost and fCost are recalculated if a better path is found
- export logic functions for Node-based tests
- add a console test demonstrating shorter routes when a shortcut exists

## Testing
- `node tests/improvement.js`

------
https://chatgpt.com/codex/tasks/task_e_6841db3da31483239a3dfd40c51b409a