### PR TITLE
Add Dijkstra algorithm and UI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@
 # [Try it online!](https://alesbe.github.io/js-pathfinder/)
 
 ## 💭 What is this project?
-This is a Pathfinder algorithm visualizer. If you're interested in learning more about this I recommend [this wikipedia article](https://en.wikipedia.org/wiki/Pathfinding), but basically, there are some algorithms that can be used to find the most optimal path between two nodes. This visualizer allows you to setup some nodes in a grid and build some obstacles, and let the program calculate the most optimal path. For now, only implements the [A* Search Algorithm](https://en.wikipedia.org/wiki/A*_search_algorithm), but I'll add more in the future!
+This is a Pathfinder algorithm visualizer. If you're interested in learning more about this I recommend [this wikipedia article](https://en.wikipedia.org/wiki/Pathfinding), but basically, there are some algorithms that can be used to find the most optimal path between two nodes. This visualizer allows you to setup some nodes in a grid and build some obstacles, and let the program calculate the most optimal path. It currently supports the [A* Search Algorithm](https://en.wikipedia.org/wiki/A*_search_algorithm) and [Dijkstra's Algorithm](https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm).
 
 ## 🧠 Usage
-- Select an algorithm
+- Select an algorithm from the **Algorithm** menu (A* or Dijkstra)
 - Draw `Starting` and `Target` nodes
 - Draw `Wall` nodes
 - Press **Visualize!**
 
 ## 📊 Implemented algorithms
 - [A* Search](https://en.wikipedia.org/wiki/A*_search_algorithm)
-- [Dijkstra's](https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm) 🚧WIP🚧
+- [Dijkstra's](https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm)

--- a/index.html
+++ b/index.html
@@ -20,11 +20,12 @@
                         <a id="clear-operation" class="nav-link text-danger" href="#">Clear</a>
                     </li>
                     <li class="nav-item dropdown">
-                        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        <a class="nav-link dropdown-toggle" href="#" id="dropdown-algorithm-selector" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                         Algorithm
                         </a>
                         <div class="dropdown-menu" id="select-algo-menu" aria-labelledby="navbarDropdown">
-                            <a class="dropdown-item" href="#">A*</a>
+                            <a id="astar-algorithm-selector" class="dropdown-item" href="#">A*</a>
+                            <a id="dijkstra-algorithm-selector" class="dropdown-item" href="#">Dijkstra</a>
                         </div>
                     </li>
                     <li class="nav-item">

--- a/js/logic.js
+++ b/js/logic.js
@@ -138,6 +138,68 @@ function aStarAlgorithm(grid) {
                     // add neighbour to OPEN
 }
 
+function dijkstraAlgorithm(grid) {
+    let openList = [];
+    let closedList = [];
+    let startingNode;
+    let targetNode;
+
+    [startingNode, targetNode] = findStartingAndTargetNodes(grid);
+
+    // Dijkstra does not use heuristics
+    grid.forEach(row => {
+        row.forEach(node => {
+            if (node.constructor.name == "Node") {
+                node.hCost = 0;
+                node.fCost = Number.MAX_SAFE_INTEGER;
+            }
+        });
+    });
+
+    startingNode.gCost = 0;
+    startingNode.fCost = 0;
+    openList.push(startingNode);
+
+    while (true) {
+        if (openList.length === 0) {
+            alert("No path found!");
+            return;
+        }
+
+        let currentNode = findLowestfCostNode(openList);
+
+        openList = openList.filter(node => node != currentNode);
+        closedList.push(currentNode);
+
+        if (currentNode.isTargetNode) {
+            console.log("Target node found! At x:", currentNode.x, " y:", currentNode.y);
+            return getNodePath(currentNode);
+        }
+
+        let currentNeighbours = findNeighbours(grid, currentNode);
+        currentNeighbours.forEach(neighbour => {
+            let isNodeInClosed = closedList.find(node => (node.x == neighbour.x) && (node.y == neighbour.y)) ? true : false;
+
+            if (neighbour.constructor.name == "WallNode" || isNodeInClosed) {
+                return;
+            }
+
+            const moveCost = currentNode.gCost + ((currentNode.x === neighbour.x || currentNode.y === neighbour.y) ? 10 : 14);
+            let isNodeInOpen = openList.find(node => (node.x == neighbour.x) && (node.y == neighbour.y)) ? true : false;
+
+            if (moveCost < neighbour.gCost || !isNodeInOpen) {
+                neighbour.gCost = moveCost;
+                neighbour.fCost = neighbour.gCost; // heuristic is zero
+                neighbour.setParent(currentNode);
+
+                if (!isNodeInOpen) {
+                    openList.push(neighbour);
+                }
+            }
+        });
+    }
+}
+
 /* Helpers */
 function findStartingAndTargetNodes(grid) {
     let startingNode;
@@ -291,12 +353,15 @@ function loadAlgorithm(algorithmNumber, grid) {
             let path = aStarAlgorithm(initGrid(grid));
             console.log(path);
             return path;
-    
+
+        case 1:
+            return dijkstraAlgorithm(initGrid(grid));
+
         default:
-            break;
+            return aStarAlgorithm(initGrid(grid));
     }
 }
 
 if (typeof module !== 'undefined') {
-    module.exports = { Node, WallNode, aStarAlgorithm, initGrid, loadAlgorithm };
+    module.exports = { Node, WallNode, aStarAlgorithm, dijkstraAlgorithm, initGrid, loadAlgorithm };
 }

--- a/js/render.js
+++ b/js/render.js
@@ -9,6 +9,11 @@ const startingNodeSelector = document.getElementById("starting-node-selector");
 const targetNodeSelector = document.getElementById("target-node-selector");
 const clearNodeSelector = document.getElementById("clear-node-selector");
 
+/* Algorithm selectors */
+const dropdownAlgorithmSelector = document.getElementById("dropdown-algorithm-selector");
+const astarAlgorithmSelector = document.getElementById("astar-algorithm-selector");
+const dijkstraAlgorithmSelector = document.getElementById("dijkstra-algorithm-selector");
+
 /* Operation selector */
 const clearOperation = document.getElementById("clear-operation");
 const visualizeOperation = document.getElementById("visualize-operation");
@@ -28,6 +33,7 @@ const AlgorithmType = {
 
 /* States */
 let nodeTypeState = NodeState.Clear;
+let algorithmTypeState = AlgorithmType.Astar;
 
 function clearGrid() {
   for(let row of gridContainer.childNodes) {
@@ -115,6 +121,17 @@ function paintNode(row, col) {
 }
 
 // Setup navbar
+astarAlgorithmSelector.onclick = (e) => {
+  e.preventDefault();
+  algorithmTypeState = AlgorithmType.Astar;
+  dropdownAlgorithmSelector.innerHTML = "A*";
+}
+dijkstraAlgorithmSelector.onclick = (e) => {
+  e.preventDefault();
+  algorithmTypeState = AlgorithmType.Dijkstra;
+  dropdownAlgorithmSelector.innerHTML = "Dijkstra";
+}
+
 wallNodeSelector.onclick = (e) => {
   e.preventDefault();
   nodeTypeState = NodeState.Wall;
@@ -141,7 +158,7 @@ clearOperation.onclick = () => {
 }
 visualizeOperation.onclick = () => {
   let parsedGrid = parseGrid();
-  let path = loadAlgorithm(AlgorithmType.Astar, parsedGrid)
+  let path = loadAlgorithm(algorithmTypeState, parsedGrid)
 
   path.forEach(node => {
     paintNode(node[0], node[1]);


### PR DESCRIPTION
## Summary
- implement `dijkstraAlgorithm` using existing Node classes
- run chosen algorithm in `loadAlgorithm`
- expose new algorithm to the UI with dropdown selection
- add menu options in HTML
- document how to use both algorithms

## Testing
- `node tests/improvement.js`
- `node - <<'NODE'
const { loadAlgorithm } = require('./js/logic.js');
const grid = [
  [2,0,0,0,3],
  [1,1,1,1,1],
  [0,0,0,0,0],
];
console.log('A* path length:', loadAlgorithm(0, grid).length);
console.log('Dijkstra path length:', loadAlgorithm(1, grid).length);
NODE`

------
https://chatgpt.com/codex/tasks/task_e_6841dc8a55788323846dba8080996bbb